### PR TITLE
Fix query param mixup

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ function doExport(options, onFinished, onError)
     }
     else
     {
-        queryParams += "assets=auto";
+        queryParams += "assets=auto&";
     }
 
     // check for json filename option to specify the json filename


### PR DESCRIPTION
An ampersand was missing in the generated download URL of the patch archive, which resulted in the query params being mixed up, e.g.:

```
https://cables.gl/api/project/LtvaAG/export?skipBackups=true&assets=autojsonName=patch&
```

-> **assets=autojsonName**

Using the URL above, the json file should be named `patch.json`, which is not the case.

This happens when calling the cli like this:
```
node index.js -e LtvaAG -d cables -j patch.json --skip-backups

```

This PR fixes it. There were no other cases of missing ampersands.
