### PR TITLE
fix command line args parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,6 @@ const cmdOptions =
         },
     ];
 
-const options = commandLineArgs(cmdOptions);
 
 /**
  * Returns true if run directly via node,
@@ -392,6 +391,8 @@ const cfg = require("home-config")
 
 if (isRunAsCli())
 {
+    const options = commandLineArgs(cmdOptions);
+
     if (options.export)
     {
         if (!isApiKeyDefined())


### PR DESCRIPTION
Fixes #18 

Calls `commandLineArgs(cmdOptions)` only if is run as CLI.